### PR TITLE
Revert "Add new routes which only use nonCSPAuth"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,10 @@ Run Integration Tests: `sbt it:test`
 
 ## API
 
-| Path | Supported Methods | Type     | Description                                                    |
-| ---------------------------------------------------------| ----------------- |----------|----------------------------------------------------------------|
-|```/```                                                   |        POST       | External | Endpoint for users to save IE315 xml to the database.          |
-|```/:mrn```                                               |        PUT        | External | Endpoint for users to save IE313 xml to the database.          |
-|```/import-control/declaration/submit```                  |        POST       | Internal | Endpoint for internal users to save IE315 xml to the database. |
-|```/import-control/amendment/submit/:mrn```               |        PUT        | Internal | Endpoint for internal users to save IE313 xml to the database. |
+| Path | Supported Methods | Type | Description |
+| ----------------------------------------------------------| ----------------- | -----| ------------|
+|```/```                                                    |        POST       | External | Endpoint for users to save IE315 xml to the database. |
+|```/:mrn```                                                |        PUT        | External | Endpoint for users to save IE313 xml to the database. |
 |```/import-control/entry-summary-declaration/:id```        |        GET        | Internal | Endpoint for C&IT to get an entry declaration from the database. |
 |```/import-control/amendment/acceptance-enrichment/:id```  |        GET        | Internal | Endpoint for [Decision microservice](https://github.com/hmrc/import-control-entry-declaration-decision) to get an acceptance enrichment from the amendment in the database. |
 |```/import-control/declaration/acceptance-enrichment/:id```|        GET        | Internal | Endpoint for [Decision microservice](https://github.com/hmrc/import-control-entry-declaration-decision) to get an acceptance enrichment from the declaration in the database. |

--- a/app/uk/gov/hmrc/entrydeclarationstore/controllers/AuthorisedController.scala
+++ b/app/uk/gov/hmrc/entrydeclarationstore/controllers/AuthorisedController.scala
@@ -33,7 +33,7 @@ abstract class AuthorisedController(cc: ControllerComponents) extends BackendCon
 
   val authService: AuthService
 
-  def authorisedAction(csp: Boolean): ActionBuilder[UserRequest, AnyContent] =
+  def authorisedAction(): ActionBuilder[UserRequest, AnyContent] =
     new ActionBuilder[UserRequest, AnyContent] {
 
       override def parser: BodyParser[AnyContent] = cc.parsers.defaultBodyParser
@@ -48,7 +48,7 @@ abstract class AuthorisedController(cc: ControllerComponents) extends BackendCon
           implicit val headerCarrier: HeaderCarrier = hc(request)
           implicit val headers: Headers             = request.headers
 
-          authService.authenticate(csp).flatMap {
+          authService.authenticate.flatMap {
             case Some(userDetails) => block(UserRequest(request, userDetails))
             case None              => error(StandardError.Unauthorized)
           }

--- a/app/uk/gov/hmrc/entrydeclarationstore/controllers/EntryDeclarationSubmissionController.scala
+++ b/app/uk/gov/hmrc/entrydeclarationstore/controllers/EntryDeclarationSubmissionController.scala
@@ -66,16 +66,14 @@ class EntryDeclarationSubmissionController @Inject()(
     </ns:SuccessResponse>
   // @formatter:on
 
-  val postSubmissionExternal: Action[ByteString] = handleSubmission(None, true)
-  val postSubmission: Action[ByteString] = handleSubmission(None, false)
+  val postSubmission: Action[ByteString] = handleSubmission(None)
 
-  val postSubmissionTestOnly: Action[ByteString] = postSubmissionExternal
+  val postSubmissionTestOnly: Action[ByteString] = postSubmission
 
-  def putAmendmentExternal(mrn: String): Action[ByteString] = handleSubmission(Some(mrn), true)
-  def putAmendment(mrn: String): Action[ByteString] = handleSubmission(Some(mrn), false)
+  def putAmendment(mrn: String): Action[ByteString] = handleSubmission(Some(mrn))
 
-  private def handleSubmission(mrn: Option[String], csp: Boolean) =
-    authorisedAction(csp).async(parse.byteString) { implicit request =>
+  private def handleSubmission(mrn: Option[String]) =
+    authorisedAction().async(parse.byteString) { implicit request =>
       val receivedDateTime = Instant.now(clock)
 
       implicit val lc: LoggingContext = LoggingContext()

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,12 +1,9 @@
 # microservice specific routes
 
-POST        /                                                                             uk.gov.hmrc.entrydeclarationstore.controllers.EntryDeclarationSubmissionController.postSubmissionExternal
-PUT         /:mrn                                                                         uk.gov.hmrc.entrydeclarationstore.controllers.EntryDeclarationSubmissionController.putAmendmentExternal(mrn)
+POST        /                                                                             uk.gov.hmrc.entrydeclarationstore.controllers.EntryDeclarationSubmissionController.postSubmission
+PUT         /:mrn                                                                         uk.gov.hmrc.entrydeclarationstore.controllers.EntryDeclarationSubmissionController.putAmendment(mrn)
 
 # internal routes
-POST        /import-control/declaration/submit                                            uk.gov.hmrc.entrydeclarationstore.controllers.EntryDeclarationSubmissionController.postSubmission
-PUT         /import-control/amendment/submit/:mrn                                         uk.gov.hmrc.entrydeclarationstore.controllers.EntryDeclarationSubmissionController.putAmendment(mrn)
-
 GET         /import-control/entry-summary-declaration/:id                                 uk.gov.hmrc.entrydeclarationstore.controllers.EntryDeclarationRetrievalController.getSubmission(id)
 
 GET         /import-control/amendment/acceptance-enrichment/:id                           uk.gov.hmrc.entrydeclarationstore.controllers.EnrichmentController.getAcceptanceEnrichment(id)

--- a/test/uk/gov/hmrc/entrydeclarationstore/controllers/AuthorisedControllerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationstore/controllers/AuthorisedControllerSpec.scala
@@ -64,7 +64,7 @@ class AuthorisedControllerSpec
     class TestController extends AuthorisedController(cc) with Timer with Logging {
       override val authService: AuthService = mockAuthService
 
-      def action(): Action[AnyContent] = authorisedAction(true).async { userRequest =>
+      def action(): Action[AnyContent] = authorisedAction().async { userRequest =>
         userRequest.userDetails shouldBe userDetails
         Future.successful(Ok(Json.obj()))
       }

--- a/test/uk/gov/hmrc/entrydeclarationstore/services/AuthServiceSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationstore/services/AuthServiceSpec.scala
@@ -164,7 +164,7 @@ class AuthServiceSpec
               stubCSPAuth(cspRetrievalsNRSEnabled) returns Future.successful(cspIdentityDataRetrievalNRSEnabled)
 
               MockApiSubscriptionFieldsConnector.getAuthenticatedEoriField(clientId) returns Future.successful(Some(eori))
-              service.authenticate(true).futureValue shouldBe Some(
+              service.authenticate.futureValue shouldBe Some(
                 UserDetails(
                   eori,
                   ClientInfo(ClientType.CSP, clientId = Some(clientId), applicationId = Some(applicationId)),
@@ -178,7 +178,7 @@ class AuthServiceSpec
               stubCSPAuth(cspRetrievalsNRSEnabled) returns Future.successful(cspIdentityDataRetrievalNRSEnabled)
               MockApiSubscriptionFieldsConnector.getAuthenticatedEoriField(clientId) returns Future.successful(None)
 
-              service.authenticate(true).futureValue shouldBe None
+              service.authenticate.futureValue shouldBe None
             }
           }
         }
@@ -197,19 +197,6 @@ class AuthServiceSpec
             MockAppConfig.nrsEnabled returns true
           }
         }
-
-        "CSP flag is set to false" must {
-          "return EORI from enrolment when S&S enrolment detected" in {
-            MockAppConfig.nrsEnabled returns true
-            stubNonCSPAuth(nonCSPRetrievalNRSEnabled) returns Future.successful(
-              nonCSPRetrievalResultsNRSEnabled(
-                Enrolments(Set(validSSEnrolment(eori))))
-            )
-            service.authenticate(false).futureValue shouldBe Some(
-              UserDetails(eori, ClientInfo(ClientType.GGW), Some(identityData))
-            )
-          }
-        }
       }
 
       "NRS disabled" when {
@@ -220,7 +207,7 @@ class AuthServiceSpec
               stubCSPAuth(EmptyRetrieval) returns Future.successful(())
 
               MockApiSubscriptionFieldsConnector.getAuthenticatedEoriField(clientId) returns Future.successful(Some(eori))
-              service.authenticate(true).futureValue shouldBe Some(
+              service.authenticate.futureValue shouldBe Some(
                 UserDetails(
                   eori,
                   ClientInfo(ClientType.CSP, clientId = Some(clientId), applicationId = Some(applicationId)),
@@ -234,7 +221,7 @@ class AuthServiceSpec
               stubCSPAuth(EmptyRetrieval) returns Future.successful(())
               MockApiSubscriptionFieldsConnector.getAuthenticatedEoriField(clientId) returns Future.successful(None)
 
-              service.authenticate(true).futureValue shouldBe None
+              service.authenticate.futureValue shouldBe None
             }
           }
         }
@@ -253,19 +240,6 @@ class AuthServiceSpec
             MockAppConfig.nrsEnabled returns false
           }
         }
-
-        "CSP flag is set to false" must {
-          "return EORI from enrolment when S&S enrolment detected" in {
-            MockAppConfig.nrsEnabled returns false
-            stubNonCSPAuth(nonCSPRetrievalNRSDisabled) returns Future.successful(
-              nonCSPRetrievalResultsNRSDisabled(
-                Enrolments(Set(validSSEnrolment(eori))))
-            )
-            service.authenticate(false).futureValue shouldBe Some(
-              UserDetails(eori, ClientInfo(ClientType.GGW), None)
-            )
-          }
-        }
       }
     }
 
@@ -277,7 +251,7 @@ class AuthServiceSpec
         stubCSPAuth(EmptyRetrieval) returns Future.successful(())
 
         MockApiSubscriptionFieldsConnector.getAuthenticatedEoriField(clientId) returns Future.successful(Some(eori))
-        service.authenticate(true).futureValue shouldBe Some(
+        service.authenticate.futureValue shouldBe Some(
           UserDetails(eori, ClientInfo(ClientType.CSP, clientId = Some(clientId), applicationId = None), None))
       }
     }
@@ -289,7 +263,7 @@ class AuthServiceSpec
           stubScenario()
           stubNonCSPAuth(nonCSPRetrievalNRSDisabled) returns Future.successful(nonCSPRetrievalResultsNRSDisabled(
             Enrolments(Set(validSSEnrolment(eori)))))
-          service.authenticate(true).futureValue shouldBe Some(UserDetails(eori, ClientInfo(ClientType.GGW), None))
+          service.authenticate.futureValue shouldBe Some(UserDetails(eori, ClientInfo(ClientType.GGW), None))
         }
       }
 
@@ -298,7 +272,7 @@ class AuthServiceSpec
           stubScenario()
           stubNonCSPAuth(nonCSPRetrievalNRSDisabled) returns Future.successful(nonCSPRetrievalResultsNRSDisabled(
             Enrolments(Set(validSSEnrolment(eori).copy(identifiers = Nil)))))
-          service.authenticate(true).futureValue shouldBe None
+          service.authenticate.futureValue shouldBe None
         }
 
         "no S&S enrolment in authorization header" in {
@@ -311,26 +285,26 @@ class AuthServiceSpec
                   identifiers       = Seq(EnrolmentIdentifier(identifier, eori)),
                   state             = "Activated",
                   delegatedAuthRule = None)))))
-          service.authenticate(true).futureValue shouldBe None
+          service.authenticate.futureValue shouldBe None
         }
 
         "no enrolments at all in authorization header" in {
           stubScenario()
           stubNonCSPAuth(nonCSPRetrievalNRSDisabled) returns Future.successful(nonCSPRetrievalResultsNRSDisabled(Enrolments(Set.empty)))
-          service.authenticate(true).futureValue shouldBe None
+          service.authenticate.futureValue shouldBe None
         }
 
         "S&S enrolment not activated" in {
           stubScenario()
           stubNonCSPAuth(nonCSPRetrievalNRSDisabled) returns Future.successful(nonCSPRetrievalResultsNRSDisabled(
             Enrolments(Set(validSSEnrolment(eori).copy(state = "inactive")))))
-          service.authenticate(true).futureValue shouldBe None
+          service.authenticate.futureValue shouldBe None
         }
 
         "authorisation fails" in {
           stubScenario()
           stubNonCSPAuth(nonCSPRetrievalNRSDisabled) returns Future.failed(authException)
-          service.authenticate(true).futureValue shouldBe None
+          service.authenticate.futureValue shouldBe None
         }
       }
     }
@@ -342,7 +316,7 @@ class AuthServiceSpec
           stubScenario()
           stubNonCSPAuth(nonCSPRetrievalNRSEnabled) returns Future.successful(nonCSPRetrievalResultsNRSEnabled(
             Enrolments(Set(validSSEnrolment(eori)))))
-          service.authenticate(true).futureValue shouldBe Some(
+          service.authenticate.futureValue shouldBe Some(
             UserDetails(eori, ClientInfo(ClientType.GGW), Some(identityData)))
         }
       }
@@ -352,7 +326,7 @@ class AuthServiceSpec
           stubScenario()
           stubNonCSPAuth(nonCSPRetrievalNRSEnabled) returns Future.successful(nonCSPRetrievalResultsNRSEnabled(
             Enrolments(Set(validSSEnrolment(eori).copy(identifiers = Nil)))))
-          service.authenticate(true).futureValue shouldBe None
+          service.authenticate.futureValue shouldBe None
         }
 
         "no S&S enrolment in authorization header" in {
@@ -365,25 +339,25 @@ class AuthServiceSpec
                   identifiers       = Seq(EnrolmentIdentifier(identifier, eori)),
                   state             = "Activated",
                   delegatedAuthRule = None)))))
-          service.authenticate(true).futureValue shouldBe None
+          service.authenticate.futureValue shouldBe None
         }
         "no enrolments at all in authorization header" in {
           stubScenario()
           stubNonCSPAuth(nonCSPRetrievalNRSEnabled) returns Future.successful(nonCSPRetrievalResultsNRSEnabled(Enrolments(Set.empty)))
-          service.authenticate(true).futureValue shouldBe None
+          service.authenticate.futureValue shouldBe None
         }
 
         "S&S enrolment not activated" in {
           stubScenario()
           stubNonCSPAuth(nonCSPRetrievalNRSEnabled) returns Future.successful(nonCSPRetrievalResultsNRSEnabled(
             Enrolments(Set(validSSEnrolment(eori).copy(state = "inactive")))))
-          service.authenticate(true).futureValue shouldBe None
+          service.authenticate.futureValue shouldBe None
         }
 
         "authorisation fails" in {
           stubScenario()
           stubNonCSPAuth(nonCSPRetrievalNRSEnabled) returns Future.failed(authException)
-          service.authenticate(true).futureValue shouldBe None
+          service.authenticate.futureValue shouldBe None
         }
       }
     }

--- a/test/uk/gov/hmrc/entrydeclarationstore/services/MockAuthService.scala
+++ b/test/uk/gov/hmrc/entrydeclarationstore/services/MockAuthService.scala
@@ -29,11 +29,10 @@ trait MockAuthService extends MockFactory {
 
   object MockAuthService {
     def authenticate: CallHandler[Future[Option[UserDetails]]] =
-      (mockAuthService.authenticate(_: Boolean)(_: HeaderCarrier, _: Headers)).expects(*, *, *)
+      (mockAuthService.authenticate(_: HeaderCarrier, _: Headers)).expects(*, *)
 
     def authenticateCapture(headerCarrier: CaptureOne[HeaderCarrier]): CallHandler[Future[Option[UserDetails]]] =
-      (mockAuthService.authenticate(_: Boolean)(_: HeaderCarrier, _: Headers)).expects(*, capture(headerCarrier), *)
-
+      (mockAuthService.authenticate(_: HeaderCarrier, _: Headers)).expects(capture(headerCarrier), *)
   }
 
 }


### PR DESCRIPTION
Reverts hmrc/import-control-entry-declaration-store#144

This work has been placed on hold and consequently we should reverse the changes that added new routes where we are not sure when the work will re-commence